### PR TITLE
Added three new options for magcutout if box extends beyond image bounds

### DIFF
--- a/R/magimage.R
+++ b/R/magimage.R
@@ -65,7 +65,7 @@ magimage<-function(x, y, z, zlim, xlim, ylim, col = grey((0:1e3)/1e3), add = FAL
   return=list(x=x, y=y, z=z)
 }
 
-magcutout=function(image, loc = dim(image)/2, box = c(101, 101), plot = FALSE, ...){
+magcutout=function(image, loc = dim(image)/2, box = c(101, 101), shiftloc=TRUE, paddim=TRUE, plot = FALSE, ...){
   loc = as.numeric(loc)
   xcen = loc[1]
   ycen = loc[2]
@@ -74,22 +74,50 @@ magcutout=function(image, loc = dim(image)/2, box = c(101, 101), plot = FALSE, .
   xhi = ceiling(loc[1] + (box[1]/2 - 0.5))
   ylo = ceiling(loc[2] - (box[2]/2 - 0.5))
   yhi = ceiling(loc[2] + (box[2]/2 - 0.5))
-  if (xlo < 1) {
+  
+  expand = paddim && shiftloc
+  diffxlo = xlo - 1
+  if (diffxlo < 0) {
     xlo = 1
-    xhi = xlo + (box[1] - 1)
+    if(expand) xhi = xlo + (box[1] - 1)
   }
-  if (xhi > dim(image)[1]) {
+  diffxhi = xhi - dim(image)[1]
+  if (diffxhi > 0) {
     xhi = dim(image)[1]
+    if(expand) {
+	    xlo = xlo - diffxhi
+	    if(xlo < 1) xlo = 1
+    }
   }
-  if (ylo < 1) {
+  diffylo = ylo - 1
+  if (diffylo < 0) {
     ylo = 1
-    yhi = ylo + (box[2] - 1)
+    if(expand) yhi = ylo + (box[2] - 1)
   }
-  if (yhi > dim(image)[2]) {
+  diffyhi = yhi - dim(image)[2]
+  if (diffyhi > 0) {
     yhi = dim(image)[2]
+    if(expand) {
+	    ylo = ylo - diffyhi
+	    if(ylo < 1) ylo = 1
+    }
   }
-  image = image[xlo:xhi, ylo:yhi]
-  output = list(image = image, loc = c(x=xcen-xlo+1, y=ycen-ylo+1), loc.orig = c(x=xcen, y=ycen), loc.diff = c(x=xlo-1, y=ylo-1), xsel = xlo:xhi, ysel = ylo:yhi)
+  if(!paddim && !shiftloc)
+  {
+  	if(diffxlo < 0 && (-diffxlo > diffxhi)) xhi = xhi - max(diffxhi,0) + diffxlo
+  	if(diffxhi > 0 && (-diffxlo < diffxhi)) xlo = xlo + diffxhi - min(diffxlo,0)
+  	if(diffylo < 0 && (-diffylo > diffyhi)) yhi = yhi - max(diffyhi,0) + diffylo
+  	if(diffyhi > 0 && (-diffylo < diffyhi)) ylo = ylo + diffyhi - min(diffylo,0)
+  }
+  xsel = xlo:xhi
+  ysel = ylo:yhi
+  image = image[xsel, ysel]
+  if(paddim && !shiftloc && any(c(diffxlo,-diffxhi,diffylo,-diffyhi) < 0)) {
+  	padded = matrix(NA,box[1],box[2])
+  	padded[xsel-diffxlo,ysel-diffylo] = image
+  	image = padded
+  }
+  output = list(image = image, loc = c(x=xcen-xlo+1, y=ycen-ylo+1), loc.orig = c(x=xcen, y=ycen), loc.diff = c(x=xlo-1, y=ylo-1), xsel = xsel, ysel = ysel)
   if (plot) {
     magimage(image, ...)
   }

--- a/R/magimageWCS.R
+++ b/R/magimageWCS.R
@@ -275,7 +275,7 @@ magimageWCSCompass=function(header, position='topright', com.col='green', com.le
   text(endxyE[1,1], endxyE[1,2], labels='E', col=com.col, adj=c(0.5,0.5))
 }
 
-magcutoutWCS=function(image, header, loc, box = c(101, 101), plot = FALSE, CRVAL1=0, CRVAL2=0, CRPIX1=0, CRPIX2=0, CD1_1=1, CD1_2=0, CD2_1=0, CD2_2=1, coord.type='deg', sep=':', loc.type=c('coord','coord'), ...){
+magcutoutWCS=function(image, header, loc, box = c(101, 101), shiftloc=TRUE, paddim=TRUE, plot = FALSE, CRVAL1=0, CRVAL2=0, CRPIX1=0, CRPIX2=0, CD1_1=1, CD1_2=0, CD2_1=0, CD2_2=1, coord.type='deg', sep=':', loc.type=c('coord','coord'), ...){
   if(length(loc.type)==1){loc.type=rep(loc.type,2)}
   if(!missing(image)){
     if(any(names(image)=='imDat') & missing(header)){
@@ -333,26 +333,13 @@ magcutoutWCS=function(image, header, loc, box = c(101, 101), plot = FALSE, CRVAL
     box=c(xhi-xlo+1,yhi-ylo+1)
   }else{
     loc = ceiling(c(xcen,ycen))
-    xlo = ceiling(loc[1] - (box[1]/2 - 0.5))
-    xhi = ceiling(loc[1] + (box[1]/2 - 0.5))
-    ylo = ceiling(loc[2] - (box[2]/2 - 0.5))
-    yhi = ceiling(loc[2] + (box[2]/2 - 0.5))
   }
-  if (xlo < 1) {
-    xlo = 1
-    xhi = xlo + (box[1] - 1)
-  }
-  if (xhi > dim(image)[1]) {
-    xhi = dim(image)[1]
-  }
-  if (ylo < 1) {
-    ylo = 1
-    yhi = ylo + (box[2] - 1)
-  }
-  if (yhi > dim(image)[2]) {
-    yhi = dim(image)[2]
-  }
-  cut_image = image[xlo:xhi, ylo:yhi]
+  cutout = magcutout(image, loc = loc, box = box, shiftloc=shiftloc, paddim=paddim, plot = FALSE)
+  cut_image = cutout$image
+  xlo = cutout$xsel[1]
+  xhi = cutout$xsel[length(cutout$xsel)]
+  ylo = cutout$ysel[1]
+  yhi = cutout$ysel[length(cutout$ysel)]
   xcen.new=xcen-xlo+1
   ycen.new=ycen-ylo+1
   xscale=abs(diff(magWCSxy2radec(c(xcen,xcen+1), c(ycen, ycen), header=header, CRVAL1=CRVAL1, CRVAL2=CRVAL2, CRPIX1=CRPIX1, CRPIX2=CRPIX2, CD1_1=CD1_1, CD1_2=CD1_2, CD2_1=CD2_1, CD2_2=CD2_2)))

--- a/man/magcutoutWCS.Rd
+++ b/man/magcutoutWCS.Rd
@@ -11,10 +11,11 @@ Image Cutout Utilities
 Functions to subset both raw images and images with associated WCS systems.
 }
 \usage{
-magcutout(image, loc = dim(image)/2, box = c(101, 101), plot = FALSE, ...)
-magcutoutWCS(image, header, loc, box = c(101, 101), plot = FALSE, CRVAL1 = 0, CRVAL2 = 0,
-CRPIX1 = 0, CRPIX2 = 0, CD1_1 = 1, CD1_2 = 0, CD2_1 = 0, CD2_2 = 1, coord.type = "deg",
-sep = ":", loc.type=c('coord','coord'), ...)
+magcutout(image, loc = dim(image)/2, box = c(101, 101), shiftloc = TRUE, paddim = TRUE,
+plot = FALSE, ...)
+magcutoutWCS(image, header, loc, box = c(101, 101), shiftloc = TRUE, paddim = TRUE,
+plot = FALSE, CRVAL1 = 0, CRVAL2 = 0, CRPIX1 = 0, CRPIX2 = 0, CD1_1 = 1, CD1_2 = 0,
+CD2_1 = 0, CD2_2 = 1, coord.type = "deg", sep = ":", loc.type=c('coord','coord'), ...)
 magWCSradec2xy(RA, Dec, header, CRVAL1 = 0, CRVAL2 = 0, CRPIX1 = 0, CRPIX2 = 0, CD1_1 = 1,
 CD1_2 = 0, CD2_1 = 0, CD2_2 = 1, loc.diff = c(0, 0), coord.type = "deg", sep = ":")
 magWCSxy2radec(x, y, header, CRVAL1 = 0, CRVAL2 = 0, CRPIX1 = 0, CRPIX2 = 0, CD1_1 = 1,
@@ -47,6 +48,12 @@ Vector; target y-pixel. Ignored if x is a matrix. Note this is the R convention 
 }
   \item{loc.diff}{
 The pixel offset to apply. Only relevant if the image being plotted is a cutout from within a FITS legal image.
+}
+	\item{shiftloc}{
+Logical; should the cutout center shift from \option{loc} if the desired \option{box} size extends beyond the edge of the image?
+}
+	\item{paddim}{
+Logical; should the cutout be padded with image data until it meets the desired \option{box} size (if \option{shiftloc} is true) or padded with NAs for data outside the image boundary otherwise?
 }
   \item{plot}{
 Logical; should a \code{\link{magimage}} (\code{magcutout}) or \code{\link{magimageWCS}} (\code{magcutoutWCS}) plot of the output be generated?
@@ -90,6 +97,10 @@ Dots are parsed to either \code{\link{magimage}} (\code{magcutout}) or \code{\li
 }
 \details{
 These functions are on a level trivial, since it is easy to subset matrices and therefore images within R. However these functions track important properties of the subset region that makes it easy to track its location with respect to the original image. Also, they allow direct plotting of the resultant cutout with the most appropriate image functions. In many cases these functions will be used purely for their plotting side effects.
+
+The \option{shiftloc} and \option{paddim} control the behaviour of the function in the non-trivial case when the desired box size extendeds beyond the edge of the image. If \option{shiftloc} is FALSE, the cutout is guaranteed to be centered on the pixel specified by \option{loc}. Then, if \option{paddim} is FALSE, the cutout extends only as far as possible until it reaches the edge of the image; otherwise, the cutout image is padded with NAs in regions outside the supplied \option{image}. If \option{shiftloc} is FALSE, the center of the cutout will be shifted. In this case, if \option{paddim} is FALSE, the cutout will extend at most half of the supplied \option{box} size from the given \option{loc}; otherwise, the cutout will be expanded until it reaches the desired \option{box} size or spans the entire image.
+
+Note that if \option{shiftloc} is TRUE and \option{paddim} is FALSE, the cutout can be larger than \option{box}; otherwise, the cutout is guaranteed to be no larger than the specified \option{box} size.
 }
 \value{
 A list containing:
@@ -107,7 +118,7 @@ A list containing:
   \item{header}{Only output from \code{magcutoutWCS}. The updated header with the correct WCS for the cutout region. Basically this means CRPIX1.new=CRPIX1.org-loc.diff[1] and CRPIX2.new=CRPIX2.org-loc.diff[2].}
 }
 \author{
-Aaron Robotham
+Aaron Robotham & Dan Taranu
 }
 \note{
 By R convention the bottom-left part of the bottom-left pixel when plotting the image matrix is c(0,0) and the top-right part of the bottom-left pixel is c(1,1), i.e. the mid-point of pixels are half integer values in x and y. This differs to the FITS convention of pixel mid points being integer values. As such the R [x,y] = FITS [x-0.5,y-0.5]. This rarely matters too much in practice, but for accurate overlays you will want to get it right (see Examples).
@@ -167,6 +178,42 @@ col='red')
 #Given we correctly modify the header, we can actually use the cut down image directly:
 
 magimageWCS(cutim)
+
+# Now test the various cutout size options by asking for a large cutout near the image boundary
+
+loc = c(300,340)
+box = c(200,200)
+loc.type = c("image","image")
+
+# By default, the cutout is exactly the request size, but the center is shifted:
+
+cutim=magcutoutWCS(image, loc=loc, box=box, coord.type="image", loc.type=loc.type,
+	plot=TRUE, shiftloc=TRUE, paddim=TRUE)
+
+# Setting shiftloc=FALSE pads the image with NAs instead, preserving the size:
+
+cutim=magcutoutWCS(image, loc=loc, box=box, coord.type="image", loc.type=loc.type,
+	plot=TRUE, shiftloc=FALSE, paddim=TRUE)
+
+# Setting paddim=FALSE returns the largest possible cutout within the image bounds,
+# without shifting the center:
+
+cutim=magcutoutWCS(image, loc=loc, box=box, coord.type="image", loc.type=loc.type, plot=TRUE,
+	shiftloc=FALSE, paddim=FALSE)
+
+# Setting paddim=FALSE and shiftloc=TRUE returns a larger cutout, but with at most
+# box/2 padding on either side:
+
+cutim=magcutoutWCS(image, loc=loc, box=box, coord.type="image", loc.type=loc.type, plot=TRUE,
+	shiftloc=TRUE, paddim=FALSE)
+
+# Setting shiftloc=FALSE and requesting a box size larger than the image returns a cutout with the
+# requested box size:
+
+box = c(400,400)
+cutim=magcutoutWCS(image, loc=loc, box=box, coord.type="image", loc.type=loc.type, plot=TRUE,
+	shiftloc=FALSE, paddim=TRUE)
+
 }
 }
 % Add one or more standard keywords, see file 'KEYWORDS' in the


### PR DESCRIPTION
I updated the docs as well. I think it all works as intended except if you set shiftloc=FALSE, paddim=FALSE and loc outside the image, in which case it gets an error. I leave it up to you to decide what should happen in that case - throw an error if loc is outside image bounds or return an empty vector?